### PR TITLE
Allow per-item container selection and group order summary by container

### DIFF
--- a/web_app/front/src/app/current_menu/model.cljs
+++ b/web_app/front/src/app/current_menu/model.cljs
@@ -30,6 +30,11 @@
    (get-in db [:page :cart])))
 
 (reg-sub
+ ::item-containers
+ (fn [db _]
+   (get-in db [:page :item-containers] {})))
+
+(reg-sub
  ::menu-items
  :<- [::daily-menu]
  (fn [{:keys [items]} _]
@@ -62,7 +67,9 @@
  ::order-summary
  :<- [::cart-total]
  :<- [::items-in-cart]
- (fn [[cart-total items-in-cart] _]
+ :<- [::item-containers]
+ (fn [[cart-total items-in-cart item-containers] _]
    {:cart-total    cart-total
     :items-in-cart items-in-cart
-    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart])}))
+    :item-containers item-containers
+    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart item-containers])}))

--- a/web_app/front/src/app/current_menu/view.cljs
+++ b/web_app/front/src/app/current_menu/view.cljs
@@ -102,19 +102,32 @@
 
 (defn order-summary
   []
-  (let [{:keys [cart-total items-in-cart on-click]} @(subscribe [::model/order-summary])
+  (let [{:keys [cart-total items-in-cart item-containers on-click]} @(subscribe [::model/order-summary])
         copied? @(subscribe [:db/get [:page :copied]])]
     (when (pos? cart-total)
       [card
        [card-header
         "Сводка заказа"]
        [card-content
-        [:div.space-y-2
-         (for [item items-in-cart]
+        [:div.space-y-3
+         (for [item items-in-cart
+               :let [container-number (get item-containers (:id item) 1)]]
            ^{:key (:id item)}
-           [:div.flex.justify-between.text-sm
-            [:span (:name item) " × " (:quantity item)]
-            (str (* (:price item) (:quantity item)) " ₽")])
+           [:div.flex.flex-col.gap-2.text-sm
+            [:div.flex.justify-between
+             [:span (:name item) " × " (:quantity item)]
+             (str (* (:price item) (:quantity item)) " ₽")]
+            [:label.flex.items-center.gap-2.text-gray-600
+             [:span "Контейнер"]
+             [:select.border.rounded.px-2.py-1.text-sm.bg-white
+              {:value     container-number
+               :on-change #(dispatch [::controller/set-item-container
+                                      (:id item)
+                                      (js/Number (.. % -target -value))])}
+              (for [option-number (range 1 6)]
+                ^{:key option-number}
+                [:option {:value option-number}
+                 (str option-number)])]]])
          [:div.border-t.pt-2.mt-2.flex.justify-between.font-medium
           [:span "Итого:"]
           [:span (str cart-total " ₽")]]


### PR DESCRIPTION
### Motivation
- Provide a way to assign selected dishes to containers (e.g. dishes 1+2 in container 1, dishes 3+4 in container 2) and reflect that grouping in the copied order summary for easy sharing.

### Description
- Add `::set-item-container` event and persist per-item container mapping under `[:page :item-containers]` in the app DB and clear it when an item is removed from cart; changes in `web_app/front/src/app/current_menu/controller.cljs`.
- Extend the order summary formatter `get-order-summary-text` to group `items-in-cart` by container and render container headings in the copied text; update `::copy-order-to-clipboard` to pass container mapping; changes in `web_app/front/src/app/current_menu/controller.cljs`.
- Expose `::item-containers` in the model and include `item-containers` in `::order-summary` payload and the `on-click` action; changes in `web_app/front/src/app/current_menu/model.cljs`.
- Add a container selector (dropdown 1–5) for each item in the order summary UI and wire it to dispatch `::set-item-container`; changes in `web_app/front/src/app/current_menu/view.cljs`.

### Testing
- Attempted to start the frontend dev server with `npm run dev`, but `shadow-cljs` failed because the `clojure` executable was not found, so the UI could not be booted and browser-based verification could not be performed (dev server did not start).
- No automated unit tests were present or run for these changes in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873d9f3bac8332adf8eabd0a7e8685)