### PR TITLE
Add drag-and-drop container assignment and grouped order summary

### DIFF
--- a/web_app/front/src/app/current_menu/controller.cljs
+++ b/web_app/front/src/app/current_menu/controller.cljs
@@ -32,24 +32,43 @@
    (let [new-count (dec (get-in db [:page :cart (:id item)] 0))]
      (if (pos? new-count)
        (assoc-in db [:page :cart (:id item)] new-count)
-       (update-in db [:page :cart] dissoc (:id item))))))
+       (-> db
+           (update-in [:page :cart] dissoc (:id item))
+           (update-in [:page :item-containers] dissoc (:id item)))))))
+
+(reg-event-db
+ ::set-item-container
+ (fn [db [_ item-id container-number]]
+   (assoc-in db [:page :item-containers item-id] container-number)))
+
+(reg-event-db
+ ::toggle-container-mode
+ (fn [db _]
+   (update-in db [:page :containers-mode] not)))
 
 (defn get-order-summary-text 
-  [cart-total items-in-cart]
-  (let [item-lines (map #(gstr/format
-                          "%s - %d шт. × %d ₽ = %d ₽"
-                          (:name %)
-                          (:quantity %)
-                          (:price %)
-                          (* (:quantity %) (:price %)))
-                        items-in-cart)]
-    (str (clojure.string/join "\n" item-lines)
+  [cart-total items-in-cart item-containers]
+  (let [items-by-container (->> items-in-cart
+                                (group-by #(get item-containers (:id %) 1))
+                                (sort-by key))
+        container-lines (map (fn [[container items]]
+                               (str "Контейнер " container ":\n"
+                                    (->> items
+                                         (map #(gstr/format
+                                                "%s - %d шт. × %d ₽ = %d ₽"
+                                                (:name %)
+                                                (:quantity %)
+                                                (:price %)
+                                                (* (:quantity %) (:price %))))
+                                         (str/join "\n"))))
+                             items-by-container)]
+    (str (str/join "\n\n" container-lines)
          "\n\nИтого: " cart-total " ₽")))
 
 (reg-event-fx
   ::copy-order-to-clipboard
-  (fn [_ [_ cart-total items-in-cart]]
-    (let [order-summary (get-order-summary-text cart-total items-in-cart)]
+  (fn [_ [_ cart-total items-in-cart item-containers]]
+    (let [order-summary (get-order-summary-text cart-total items-in-cart item-containers)]
       {:fx [[:copy-to-clipboard order-summary]
             [:dispatch [::show-copied-notification]]]})))
 

--- a/web_app/front/src/app/current_menu/model.cljs
+++ b/web_app/front/src/app/current_menu/model.cljs
@@ -30,6 +30,16 @@
    (get-in db [:page :cart])))
 
 (reg-sub
+ ::item-containers
+ (fn [db _]
+   (get-in db [:page :item-containers] {})))
+
+(reg-sub
+ ::containers-mode
+ (fn [db _]
+   (get-in db [:page :containers-mode] false)))
+
+(reg-sub
  ::menu-items
  :<- [::daily-menu]
  (fn [{:keys [items]} _]
@@ -62,7 +72,11 @@
  ::order-summary
  :<- [::cart-total]
  :<- [::items-in-cart]
- (fn [[cart-total items-in-cart] _]
+ :<- [::item-containers]
+ :<- [::containers-mode]
+ (fn [[cart-total items-in-cart item-containers containers-mode] _]
    {:cart-total    cart-total
     :items-in-cart items-in-cart
-    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart])}))
+    :item-containers item-containers
+    :containers-mode containers-mode
+    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart item-containers])}))


### PR DESCRIPTION
### Motivation
- Make per-item container assignment in the order summary more user-friendly by providing an explicit "distribution" mode with a modern drag-and-drop UX. 
- Preserve grouping in the copied order summary so shared text reflects container assignments.

### Description
- Add events `::set-item-container` and `::toggle-container-mode` and clear item container mapping when an item is removed from the cart in `web_app/front/src/app/current_menu/controller.cljs`.
- Extend the model with `::item-containers` and `::containers-mode` subscriptions and include `item-containers` and `containers-mode` in the `::order-summary` payload, and pass the mapping into the copy action in `web_app/front/src/app/current_menu/model.cljs`.
- Implement drag-and-drop UI for assigning items to containers, a toggle button to enter/exit distribution mode, and a grouped read-only view of containers when mode is off in `web_app/front/src/app/current_menu/view.cljs`.
- Update `get-order-summary-text` to group items by container and render container headings in the copied summary, and make `::copy-order-to-clipboard` accept the container mapping in `web_app/front/src/app/current_menu/controller.cljs`.

### Testing
- Ran the frontend start command `npm run dev`, but the dev build failed because `shadow-cljs` could not start due to the `clojure` executable being missing from the environment, so the UI could not be booted for browser verification. 
- No automated unit tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873d9f3bac8332adf8eabd0a7e8685)