### PR TITLE
Refine container distribution UX: opt-in mode, default 2 containers, addable vertical list

### DIFF
--- a/web_app/front/src/app/current_menu/controller.cljs
+++ b/web_app/front/src/app/current_menu/controller.cljs
@@ -32,24 +32,48 @@
    (let [new-count (dec (get-in db [:page :cart (:id item)] 0))]
      (if (pos? new-count)
        (assoc-in db [:page :cart (:id item)] new-count)
-       (update-in db [:page :cart] dissoc (:id item))))))
+       (-> db
+           (update-in [:page :cart] dissoc (:id item))
+           (update-in [:page :item-containers] dissoc (:id item)))))))
+
+(reg-event-db
+ ::set-item-container
+ (fn [db [_ item-id container-number]]
+   (assoc-in db [:page :item-containers item-id] container-number)))
+
+(reg-event-db
+ ::toggle-container-mode
+ (fn [db _]
+   (update-in db [:page :containers-mode] not)))
+
+(reg-event-db
+ ::add-container
+ (fn [db _]
+   (update-in db [:page :containers-count] (fnil inc 2))))
 
 (defn get-order-summary-text 
-  [cart-total items-in-cart]
-  (let [item-lines (map #(gstr/format
-                          "%s - %d шт. × %d ₽ = %d ₽"
-                          (:name %)
-                          (:quantity %)
-                          (:price %)
-                          (* (:quantity %) (:price %)))
-                        items-in-cart)]
-    (str (clojure.string/join "\n" item-lines)
+  [cart-total items-in-cart item-containers]
+  (let [items-by-container (->> items-in-cart
+                                (group-by #(get item-containers (:id %) 1))
+                                (sort-by key))
+        container-lines (map (fn [[container items]]
+                               (str "Контейнер " container ":\n"
+                                    (->> items
+                                         (map #(gstr/format
+                                                "%s - %d шт. × %d ₽ = %d ₽"
+                                                (:name %)
+                                                (:quantity %)
+                                                (:price %)
+                                                (* (:quantity %) (:price %))))
+                                         (str/join "\n"))))
+                             items-by-container)]
+    (str (str/join "\n\n" container-lines)
          "\n\nИтого: " cart-total " ₽")))
 
 (reg-event-fx
   ::copy-order-to-clipboard
-  (fn [_ [_ cart-total items-in-cart]]
-    (let [order-summary (get-order-summary-text cart-total items-in-cart)]
+  (fn [_ [_ cart-total items-in-cart item-containers]]
+    (let [order-summary (get-order-summary-text cart-total items-in-cart item-containers)]
       {:fx [[:copy-to-clipboard order-summary]
             [:dispatch [::show-copied-notification]]]})))
 

--- a/web_app/front/src/app/current_menu/model.cljs
+++ b/web_app/front/src/app/current_menu/model.cljs
@@ -30,6 +30,21 @@
    (get-in db [:page :cart])))
 
 (reg-sub
+ ::item-containers
+ (fn [db _]
+   (get-in db [:page :item-containers] {})))
+
+(reg-sub
+ ::containers-mode
+ (fn [db _]
+   (get-in db [:page :containers-mode] false)))
+
+(reg-sub
+ ::containers-count
+ (fn [db _]
+   (get-in db [:page :containers-count] 2)))
+
+(reg-sub
  ::menu-items
  :<- [::daily-menu]
  (fn [{:keys [items]} _]
@@ -62,7 +77,13 @@
  ::order-summary
  :<- [::cart-total]
  :<- [::items-in-cart]
- (fn [[cart-total items-in-cart] _]
+ :<- [::item-containers]
+ :<- [::containers-mode]
+ :<- [::containers-count]
+ (fn [[cart-total items-in-cart item-containers containers-mode containers-count] _]
    {:cart-total    cart-total
     :items-in-cart items-in-cart
-    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart])}))
+    :item-containers item-containers
+    :containers-mode containers-mode
+    :containers-count containers-count
+    :on-click      (h/action [::ctrl/copy-order-to-clipboard cart-total items-in-cart item-containers])}))

--- a/web_app/front/src/app/current_menu/view.cljs
+++ b/web_app/front/src/app/current_menu/view.cljs
@@ -102,19 +102,81 @@
 
 (defn order-summary
   []
-  (let [{:keys [cart-total items-in-cart on-click]} @(subscribe [::model/order-summary])
-        copied? @(subscribe [:db/get [:page :copied]])]
+  (let [{:keys [cart-total items-in-cart item-containers containers-mode containers-count on-click]}
+        @(subscribe [::model/order-summary])
+        copied? @(subscribe [:db/get [:page :copied]])
+        items-by-container (->> items-in-cart
+                                (group-by #(get item-containers (:id %) 1))
+                                (sort-by key))]
     (when (pos? cart-total)
       [card
        [card-header
         "Сводка заказа"]
        [card-content
-        [:div.space-y-2
-         (for [item items-in-cart]
-           ^{:key (:id item)}
-           [:div.flex.justify-between.text-sm
-            [:span (:name item) " × " (:quantity item)]
-            (str (* (:price item) (:quantity item)) " ₽")])
+        [:div.space-y-4
+         [:div.flex.items-center.justify-between
+          [:div.text-sm.text-gray-500
+           "Распределите блюда по контейнерам — перетащите позиции."]
+          [button
+           {:type     (if containers-mode "secondary" "primary")
+            :class    "whitespace-nowrap"
+            :on-click #(dispatch [::controller/toggle-container-mode])}
+           (if containers-mode
+             "Скрыть распределение"
+             "Распределить по контейнерам")]]
+         (if containers-mode
+           [:div.grid.gap-4.lg:grid-cols-2
+            [:div
+             [:div.text-sm.font-medium.text-gray-700.mb-2 "Позиции"]
+             [:div.space-y-2
+              (for [item items-in-cart]
+                ^{:key (:id item)}
+                [:div.flex.items-center.justify-between.text-sm.bg-gray-50.border.rounded-lg.px-3.py-2
+                 {:draggable true
+                  :on-drag-start #(do
+                                    (.setData (.-dataTransfer %) "text/plain" (str (:id item)))
+                                    (.setData (.-dataTransfer %) "application/container-item" (str (:id item))))}
+                 [:span (:name item) " × " (:quantity item)]
+                 [:span.text-gray-500 (str (* (:price item) (:quantity item)) " ₽")]])]]
+            [:div
+             [:div.flex.items-center.justify-between.mb-2
+              [:div.text-sm.font-medium.text-gray-700 "Контейнеры"]
+              [button
+               {:type     "secondary"
+                :class    "text-xs px-2 py-1"
+                :on-click #(dispatch [::controller/add-container])}
+               "+ Контейнер"]]
+             [:div.space-y-3
+              (for [container-number (range 1 (inc containers-count))]
+                ^{:key container-number}
+                [:div.border.rounded-lg.p-3.bg-white.min-h-[110px]
+                 {:on-drag-over #(.preventDefault %)
+                  :on-drop #(let [item-id (js/Number (.getData (.-dataTransfer %) "application/container-item"))]
+                              (when (pos? item-id)
+                                (dispatch [::controller/set-item-container item-id container-number])))}
+                 [:div.flex.items-center.justify-between.mb-2
+                  [:span.font-medium (str "Контейнер " container-number)]
+                  [:span.text-xs.text-gray-400 "Drop"]]
+                 (if-let [container-items (seq (get (into {} items-by-container) container-number))]
+                   [:div.space-y-1
+                    (for [item container-items]
+                      ^{:key (:id item)}
+                      [:div.text-xs.text-gray-700.flex.justify-between
+                       [:span (:name item) " × " (:quantity item)]
+                       [:span (str (* (:price item) (:quantity item)) " ₽")]])]
+                   [:div.text-xs.text-gray-400 "Перетащите блюда сюда"])])]]]
+           [:div.space-y-2
+            (for [[container-number container-items] items-by-container]
+              ^{:key container-number}
+              [:div
+               [:div.text-xs.uppercase.tracking-wide.text-gray-400.mb-1
+                (str "Контейнер " container-number)]
+               [:div.space-y-1
+                (for [item container-items]
+                  ^{:key (:id item)}
+                  [:div.flex.justify-between.text-sm
+                   [:span (:name item) " × " (:quantity item)]
+                   (str (* (:price item) (:quantity item)) " ₽")])]])])
          [:div.border-t.pt-2.mt-2.flex.justify-between.font-medium
           [:span "Итого:"]
           [:span (str cart-total " ₽")]]


### PR DESCRIPTION
### Motivation

- Make container assignment opt-in so distribution UI is hidden by default and only activated when needed. 
- Start with two containers and allow users to add more on demand. 
- Present container drop zones in a vertical list for easier scanning and mobile friendliness. 

### Description

- Controller updates: add `::set-item-container`, `::toggle-container-mode`, and `::add-container` handlers, clear item->container mapping when an item is removed, update `get-order-summary-text` to accept `item-containers`, and make `::copy-order-to-clipboard` accept the container mapping (`web_app/front/src/app/current_menu/controller.cljs`).
- Model updates: add `::item-containers`, `::containers-mode`, and `::containers-count` subscriptions and include `item-containers`, `containers-mode`, and `containers-count` in the `::order-summary` payload and copy action (`web_app/front/src/app/current_menu/model.cljs`).
- View updates: keep distribution opt-in via a toggle button, add a `+ Контейнер` button that increments the container count, render containers vertically (`:div.space-y-3`), implement drag-and-drop drop zones that dispatch `::set-item-container`, and show a grouped read-only view when distribution mode is off (`web_app/front/src/app/current_menu/view.cljs`).
- UX details: default container index is `1` for unassigned items in grouping, `containers-count` defaults to `2`, and the copy text now groups items under container headings.

### Testing

- Ran `npm run dev` in the front-end; the dev process failed to start because `shadow-cljs` requires the `clojure` executable which is missing in the environment. 
- No automated unit tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873d9f3bac8332adf8eabd0a7e8685)